### PR TITLE
add action hook so we can save the messageid after the email is sent

### DIFF
--- a/wp-mail.php
+++ b/wp-mail.php
@@ -195,6 +195,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
     $response = wp_remote_post( 'https://api.postmarkapp.com/email', $args );
 
     if ( is_wp_error( $response ) || 200 != wp_remote_retrieve_response_code( $response ) ) {
+        do_action('postmark_error', $response, $headers);
 	Postmark_Mail::$LAST_ERROR = $response;
         return false;
     }

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -199,5 +199,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
         return false;
     }
 
+    do_action('postmark_response', $response, $headers);
+
     return true;
 }


### PR DESCRIPTION
This is an enhancement for the issue #22 

This feature will allow us to save MessageID after the email is sent.

If you want to save the MessageID to a POST, then you need to add the post id to the $headers argument of wp_mail function. This will not create any malfunctions with email part, because the headers does get filtered to a new variable ($recognized_headers).

For example:
`$headers['post_id'] = $post_id;`

Arguments sent with the hook:
$response = response from postmarkapp API
$headers = headers from wp_mail function

So after the email is sent, we can catch the response_data by adding an action hook.
`add_action('postmark_response', 'handle_postmark_response', 10, 2);`

`function handle_postmark_response($response_data, $headers)
{`
     `$response_data = json_decode($response_data['body']);`
   `  $post_id = $headers['post_id'];`
 `    $message_id = $response_data->MessageID;`
`}`
