### PR TITLE
Add Email Recipient Override

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -5,7 +5,7 @@
         $('.pm-enabled').prop('checked', settings.enabled);
         $('.pm-api-key').val(settings.api_key);
         $('.pm-sender-address').val(settings.sender_address);
-      $('.pm-test-recipient-address').val(settings.override_recipient_address);
+        $('.pm-override-recipient-address').val(settings.override_recipient_address);
         $('.pm-force-html').prop('checked', settings.force_html);
         $('.pm-track-opens').prop('checked', settings.track_opens);
         $('.pm-enable-logs').prop('checked', settings.enable_logs);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -16,7 +16,7 @@
                 'enabled': $('.pm-enabled').is(':checked') ? 1 : 0,
                 'api_key': $('.pm-api-key').val(),
                 'sender_address': $('.pm-sender-address').val(),
-                'test_email': $('.pm-override-recipient-address').val(),
+                'override_recipient_address': $('.pm-override-recipient-address').val(),
                 'force_html': $('.pm-force-html').is(':checked') ? 1 : 0,
                 'track_opens': $('.pm-track-opens').is(':checked') ? 1 : 0,
                 'enable_logs': $('.pm-enable-logs').is(':checked') ? 1 : 0

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -5,6 +5,7 @@
         $('.pm-enabled').prop('checked', settings.enabled);
         $('.pm-api-key').val(settings.api_key);
         $('.pm-sender-address').val(settings.sender_address);
+        $('.pm-test-recipient-address').val(settings.test_email);
         $('.pm-force-html').prop('checked', settings.force_html);
         $('.pm-track-opens').prop('checked', settings.track_opens);
         $('.pm-enable-logs').prop('checked', settings.enable_logs);
@@ -15,6 +16,7 @@
                 'enabled': $('.pm-enabled').is(':checked') ? 1 : 0,
                 'api_key': $('.pm-api-key').val(),
                 'sender_address': $('.pm-sender-address').val(),
+                'test_email': $('.pm-test-recipient-address').val(),
                 'force_html': $('.pm-force-html').is(':checked') ? 1 : 0,
                 'track_opens': $('.pm-track-opens').is(':checked') ? 1 : 0,
                 'enable_logs': $('.pm-enable-logs').is(':checked') ? 1 : 0

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -5,7 +5,7 @@
         $('.pm-enabled').prop('checked', settings.enabled);
         $('.pm-api-key').val(settings.api_key);
         $('.pm-sender-address').val(settings.sender_address);
-        $('.pm-test-recipient-address').val(settings.test_email);
+      $('.pm-test-recipient-address').val(settings.override_recipient_address);
         $('.pm-force-html').prop('checked', settings.force_html);
         $('.pm-track-opens').prop('checked', settings.track_opens);
         $('.pm-enable-logs').prop('checked', settings.enable_logs);
@@ -16,7 +16,7 @@
                 'enabled': $('.pm-enabled').is(':checked') ? 1 : 0,
                 'api_key': $('.pm-api-key').val(),
                 'sender_address': $('.pm-sender-address').val(),
-                'test_email': $('.pm-test-recipient-address').val(),
+                'test_email': $('.pm-override-recipient-address').val(),
                 'force_html': $('.pm-force-html').is(':checked') ? 1 : 0,
                 'track_opens': $('.pm-track-opens').is(':checked') ? 1 : 0,
                 'enable_logs': $('.pm-enable-logs').is(':checked') ? 1 : 0

--- a/page-settings.php
+++ b/page-settings.php
@@ -97,6 +97,13 @@ wp_nonce_field( 'postmark_nonce' );
                     <span class="footnote">Log send attempts for historical/troubleshooting purposes (Recommended).</span>
                 </td>
             </tr>
+            <tr>
+                <th><label>Test Recipient</label></th>
+                <td>
+                    <input type="email" class="pm-test-recipient-address" value="" />
+                    <div class="footnote">All emails sent through Postmark will be delievered to this email. Useful for staging and development environments.</div>
+                </td>
+            </tr>
         </table>
 
         <div class="submit">

--- a/page-settings.php
+++ b/page-settings.php
@@ -101,7 +101,7 @@ wp_nonce_field( 'postmark_nonce' );
                 <th><label>Override Recipient</label></th>
                 <td>
                     <input type="email" class="pm-override-recipient-address" value="" />
-                    <div class="footnote">All emails sent through Postmark will be automatically delivered to this address (or comma separated addresses). Useful for environments, e.g. staging or development, where emails should not be sent to real users.</div>
+                    <div class="footnote">All emails sent through Postmark will be automatically delivered to this address instead of the original recipient(s). Useful for environments, e.g. staging or development, where emails should not be sent to real users.</div>
                 </td>
             </tr>
         </table>

--- a/page-settings.php
+++ b/page-settings.php
@@ -98,10 +98,10 @@ wp_nonce_field( 'postmark_nonce' );
                 </td>
             </tr>
             <tr>
-                <th><label>Test Recipient</label></th>
+                <th><label>Override Recipient</label></th>
                 <td>
-                    <input type="email" class="pm-test-recipient-address" value="" />
-                    <div class="footnote">All emails sent through Postmark will be delievered to this email. Useful for staging and development environments.</div>
+                    <input type="email" class="pm-override-recipient-address" value="" />
+                    <div class="footnote">All emails sent through Postmark will be automatically be delievered to address. Useful for staging and development environments where emails should not be sent to real users.</div>
                 </td>
             </tr>
         </table>

--- a/page-settings.php
+++ b/page-settings.php
@@ -101,7 +101,7 @@ wp_nonce_field( 'postmark_nonce' );
                 <th><label>Override Recipient</label></th>
                 <td>
                     <input type="email" class="pm-override-recipient-address" value="" />
-                    <div class="footnote">All emails sent through Postmark will be automatically be delievered to address. Useful for staging and development environments where emails should not be sent to real users.</div>
+                    <div class="footnote">All emails sent through Postmark will be automatically delivered to this address (or comma separated addresses). Useful for environments, e.g. staging or development, where emails should not be sent to real users.</div>
                 </td>
             </tr>
         </table>

--- a/postmark.php
+++ b/postmark.php
@@ -105,25 +105,6 @@ class Postmark_Mail
        wp_die();
     }
 
-    /**
-     * Accepts array or emails or a single email, checks if the given
-     * email(s) are set and valid email addresses. Returns true if all emails
-     * are valid and false if at least one email is invalid.
-     */
-    function verify_email_addresses($emails) {
-        if ( is_array($emails) ) {
-            foreach ($emails as $email) {
-                if ( ! isset($email) || ! is_email($email) ) {
-                    return false;
-                }
-            }
-        } else {
-            return isset($emails) && is_email($emails);
-        }
-
-        return true;
-    }
-
     function send_test_email() {
 	    // We check the wp_nonce.
 	    if ( ! isset($_POST['_wpnonce']) || ! wp_verify_nonce( $_POST['_wpnonce'], 'postmark_nonce' ) ) {

--- a/postmark.php
+++ b/postmark.php
@@ -224,7 +224,7 @@ class Postmark_Mail
 	        $settings['test_email'] = sanitize_email($data['test_email']);
         }
         else {
-	        $settings['sender_address'] = '';
+	        $settings['test_email'] = '';
         }
 
         // We validate that 'force_html' is a numeric boolean

--- a/postmark.php
+++ b/postmark.php
@@ -44,7 +44,7 @@ class Postmark_Mail
                 'track_opens'       => get_option( 'postmark_trackopens', 0 ),
                 'track_links'       => get_option( 'postmark_tracklinks', 0 ),
                 'enable_logs'       => get_option( 'postmark_enable_logs', 1 ),
-                'test_email'        => get_option( 'postmark_test_email', ''),
+                'override_recipient_address' => get_option( 'postmark_override_recipient_address', '' ),
             );
 
             update_option( 'postmark_settings', json_encode( $settings ) );
@@ -219,12 +219,12 @@ class Postmark_Mail
 	        $settings['sender_address'] = '';
         }
 
-        // We validate that 'test_email' is a valid email address
-        if ( isset($data['test_email']) && is_email($data['test_email']) ) {
-	        $settings['test_email'] = sanitize_email($data['test_email']);
+        // We validate that 'override_recipient_address' is a valid email address
+        if ( isset($data['override_recipient_address']) && is_email($data['override_recipient_address']) ) {
+	        $settings['override_recipient_address'] = sanitize_email($data['override_recipient_address']);
         }
         else {
-	        $settings['test_email'] = '';
+	        $settings['override_recipient_address'] = '';
         }
 
         // We validate that 'force_html' is a numeric boolean

--- a/postmark.php
+++ b/postmark.php
@@ -43,7 +43,8 @@ class Postmark_Mail
                 'force_html'        => get_option( 'postmark_force_html', 0 ),
                 'track_opens'       => get_option( 'postmark_trackopens', 0 ),
                 'track_links'       => get_option( 'postmark_tracklinks', 0 ),
-                'enable_logs'       => get_option( 'postmark_enable_logs', 1 )
+                'enable_logs'       => get_option( 'postmark_enable_logs', 1 ),
+                'test_email'        => get_option( 'postmark_test_email', ''),
             );
 
             update_option( 'postmark_settings', json_encode( $settings ) );
@@ -213,6 +214,14 @@ class Postmark_Mail
         // We validate that 'sender_address' is a valid email address
         if ( isset($data['sender_address']) && is_email($data['sender_address']) ) {
 	        $settings['sender_address'] = sanitize_email($data['sender_address']);
+        }
+        else {
+	        $settings['sender_address'] = '';
+        }
+
+        // We validate that 'test_email' is a valid email address
+        if ( isset($data['test_email']) && is_email($data['test_email']) ) {
+	        $settings['test_email'] = sanitize_email($data['test_email']);
         }
         else {
 	        $settings['sender_address'] = '';

--- a/postmark.php
+++ b/postmark.php
@@ -105,6 +105,25 @@ class Postmark_Mail
        wp_die();
     }
 
+    /**
+     * Accepts array or emails or a single email, checks if the given
+     * email(s) are set and valid email addresses. Returns true if all emails
+     * are valid and false if at least one email is invalid.
+     */
+    function verify_email_addresses($emails) {
+        if ( is_array($emails) ) {
+            foreach ($emails as $email) {
+                if ( ! isset($email) || ! is_email($email) ) {
+                    return false;
+                }
+            }
+        } else {
+            return isset($emails) && is_email($emails);
+        }
+
+        return true;
+    }
+
     function send_test_email() {
 	    // We check the wp_nonce.
 	    if ( ! isset($_POST['_wpnonce']) || ! wp_verify_nonce( $_POST['_wpnonce'], 'postmark_nonce' ) ) {

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -127,9 +127,9 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
         $from = $recognized_headers['From'];
     }
 
-    // If test_email value is set replace $to with our test recipients
-    if ( ! empty( $settings['test_email'] ) ) {
-        $to = $settings['test_email'];
+    // If override_recipient_address value is set replace $to with our test recipients
+    if ( ! empty( $settings['override_recipient_address'] ) ) {
+        $to = $settings['override_recipient_address'];
     }
 
     $body = array(

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -18,6 +18,13 @@ function postmark_determine_mime_content_type( $filename ){
 
 function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
 
+    // If test_email value is set replace $to with our test recipients
+    $testRecipients = get_option( 'postmark_test_email', '');
+
+    if ( ! empty($testRecipients) ) {
+        $to = $testRecipients;
+    }
+
     // Compact the input, apply the filters, and extract them back out
     extract( apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) ) );
 

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -18,13 +18,6 @@ function postmark_determine_mime_content_type( $filename ){
 
 function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
 
-    // If test_email value is set replace $to with our test recipients
-    $testRecipients = get_option( 'postmark_test_email', '');
-
-    if ( ! empty($testRecipients) ) {
-        $to = $testRecipients;
-    }
-
     // Compact the input, apply the filters, and extract them back out
     extract( apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) ) );
 
@@ -132,6 +125,11 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 
     if ( isset( $recognized_headers['From'] ) ) {
         $from = $recognized_headers['From'];
+    }
+
+    // If test_email value is set replace $to with our test recipients
+    if ( ! empty( $settings['test_email'] ) ) {
+        $to = $settings['test_email'];
     }
 
     $body = array(


### PR DESCRIPTION
Hi everyone,

This PR adds a new setting on the General tab within the Postmark settings page that allows a single email address to become the only recipient for all emails sent by Postmark on the current site.  The purpose is to facilitate testing on local and staging sites where emails should still be sent, but not to real users. 

I'm not totally satisfied with the name I've chosen for the new setting **Override Recipient** (the back end option name is override_recipient_address), however I'm submitting this PR now to see if the team agrees with it's premise.  I'm open to any and all suggestions to improve.

The idea comes from the suggestion given in #10 