### PR TITLE
fix `POSTMARK_URL` string

### DIFF
--- a/postmark.php
+++ b/postmark.php
@@ -15,7 +15,7 @@ class Postmark_Mail
     function __construct() {
         define( 'POSTMARK_VERSION', '1.11.2' );
         define( 'POSTMARK_DIR', dirname( __FILE__ ) );
-        define( 'POSTMARK_URL', plugins_url( basename( POSTMARK_DIR ) ) );
+		define( 'POSTMARK_URL', plugins_url( '', __FILE__ ) );
 
         add_filter( 'init', array( $this, 'init' ) );
 


### PR DESCRIPTION
this corrects the code to generate the url string defined for `POSTMARK_URL`.
Using constants is not very elegant and discouraged in WP overall but without restructuring more of the code base this is an easy fix

Closes #5 