### PR TITLE
Add defined checks around the constants in the __construct #51

### DIFF
--- a/postmark.php
+++ b/postmark.php
@@ -13,9 +13,17 @@ class Postmark_Mail
     public static $LAST_ERROR = null;
 
     function __construct() {
-        define( 'POSTMARK_VERSION', '1.11.6' );
-        define( 'POSTMARK_DIR', dirname( __FILE__ ) );
-        define( 'POSTMARK_URL', plugins_url( basename( POSTMARK_DIR ) ) );
+        if ( ! defined( 'POSTMARK_VERSION' ) ) {
+            define( 'POSTMARK_VERSION', '1.11.6' );
+        }
+
+        if ( ! defined( 'POSTMARK_DIR' ) ) {
+            define( 'POSTMARK_DIR', dirname( __FILE__ ) );
+        }
+
+        if ( ! defined( 'POSTMARK_URL' ) ) {
+            define( 'POSTMARK_URL', plugins_url( basename( POSTMARK_DIR ) ) );
+        }
 
         add_filter( 'init', array( $this, 'init' ) );
 


### PR DESCRIPTION
Fixes #51 

Proposed changes:
1. Add `defined()` checks for each constant in the `Postmark_Mail::__construct()` method, as to avoid any additional instantiations of the class to throw notices.