### PR TITLE
Allow Settings to be Overridden by Constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 [Can I use the Postmark for WordPress plugin with Divi contact forms?](https://postmarkapp.com/support/article/1128-can-i-use-the-postmark-for-wordpress-plugin-with-divi-contact-forms)
 
 ## Changelog
+### v1.14.0
+* Adds ability to override settings for environment specific Postmark plugin settings.
+
 ### v1.13.7
 * Fix limit of 500 sending logs deleted per day.
 

--- a/page-settings.php
+++ b/page-settings.php
@@ -42,6 +42,18 @@ wp_nonce_field( 'postmark_nonce' );
 
 	<div class="updated notice pm-notice hidden"></div>
 
+	<?php if ( isset( $this->overridden_settings['api_key'] ) ) : ?>
+		<div class="notice notice-info"><code>POSTMARK_API_KEY</code> is defined in your wp-config.php and overrides the <code>API Key</code> set here.</div>
+	<?php endif; ?>
+
+	<?php if ( isset( $this->overridden_settings['stream_name'] ) ) : ?>
+		<div class="notice notice-info"><code>POSTMARK_STREAM_NAME</code> is defined in your wp-config.php and overrides the <code>Message Stream</code> set here.</div>
+	<?php endif; ?>
+
+	<?php if ( isset( $this->overridden_settings['sender_address'] ) ) : ?>
+		<div class="notice notice-info"><code>POSTMARK_SENDER_ADDRESS</code> is defined in your wp-config.php and overrides the <code>Sender Email</code> set here.</div>
+	<?php endif; ?>
+
 	<div class="tab-content tab-general">
 		<table class="form-table">
 			<tr>

--- a/postmark-settings.php
+++ b/postmark-settings.php
@@ -11,5 +11,6 @@ $settings_from_constants = array(
     'stream_name'    => defined('POSTMARK_STREAM_NAME') ? POSTMARK_STREAM_NAME : null,
     'sender_address' => defined('POSTMARK_SENDER_ADDRESS') ? POSTMARK_SENDER_ADDRESS : null,
 );
+$settings_from_constants = array_filter($settings_from_constants);
 $settings = array_merge( $settings, $settings_from_constants );
 return $settings;

--- a/postmark-settings.php
+++ b/postmark-settings.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Override settings
+ *
+ * @return array $settings Settings overridden by constants
+ */
+
+$settings = json_decode( get_option( 'postmark_settings' ), true );
+$settings_from_constants = array(
+    'api_key'        => defined('POSTMARK_API_KEY') ? POSTMARK_API_KEY : null,
+    'stream_name'    => defined('POSTMARK_STREAM_NAME') ? POSTMARK_STREAM_NAME : null,
+    'sender_address' => defined('POSTMARK_SENDER_ADDRESS') ? POSTMARK_SENDER_ADDRESS : null,
+);
+$settings = array_merge( $settings, $settings_from_constants );
+return $settings;

--- a/postmark-settings.php
+++ b/postmark-settings.php
@@ -7,11 +7,11 @@
 
 $settings = json_decode( get_option( 'postmark_settings' ), true );
 $settings_from_constants = array(
-    'api_key'        => defined('POSTMARK_API_KEY') ? POSTMARK_API_KEY : null,
-    'stream_name'    => defined('POSTMARK_STREAM_NAME') ? POSTMARK_STREAM_NAME : null,
-    'sender_address' => defined('POSTMARK_SENDER_ADDRESS') ? POSTMARK_SENDER_ADDRESS : null,
+    'api_key'        => defined( 'POSTMARK_API_KEY' ) ? POSTMARK_API_KEY : null,
+    'stream_name'    => defined( 'POSTMARK_STREAM_NAME' ) ? POSTMARK_STREAM_NAME : null,
+    'sender_address' => defined( 'POSTMARK_SENDER_ADDRESS' ) ? POSTMARK_SENDER_ADDRESS : null,
 );
-$settings_from_constants = array_filter($settings_from_constants);
+$settings_from_constants = array_filter( $settings_from_constants );
 $settings = array_merge( $settings, $settings_from_constants );
 return array(
     'settings' => $settings,

--- a/postmark-settings.php
+++ b/postmark-settings.php
@@ -13,4 +13,7 @@ $settings_from_constants = array(
 );
 $settings_from_constants = array_filter($settings_from_constants);
 $settings = array_merge( $settings, $settings_from_constants );
-return $settings;
+return array(
+    'settings' => $settings,
+    'settings_from_constants' => $settings_from_constants,
+);

--- a/postmark.php
+++ b/postmark.php
@@ -3,7 +3,7 @@
  * Plugin Name: Postmark (Official)
  * Plugin URI: https://postmarkapp.com/
  * Description: Overrides wp_mail to send emails through Postmark
- * Version: 1.13.7
+ * Version: 1.14.0
  * Author: Andrew Yates & Matt Gibbs
  */
 
@@ -38,7 +38,7 @@ class Postmark_Mail {
 	 */
 	public function __construct() {
 		if ( ! defined( 'POSTMARK_VERSION' ) ) {
-			define( 'POSTMARK_VERSION', '1.13.7' );
+			define( 'POSTMARK_VERSION', '1.14.0' );
 		}
 
 		if ( ! defined( 'POSTMARK_DIR' ) ) {

--- a/postmark.php
+++ b/postmark.php
@@ -53,6 +53,7 @@ class Postmark_Mail {
 
 		$this->settings = $this->load_settings();
 		$this->overridden_settings = include POSTMARK_DIR . '/postmark-settings.php';
+		$this->overridden_settings = $this->overridden_settings['settings_from_constants'];
 	}
 
 	/**

--- a/postmark.php
+++ b/postmark.php
@@ -20,6 +20,13 @@ class Postmark_Mail {
 	public $settings;
 
 	/**
+	 * Overridden Settings.
+	 *
+	 * @var array
+	 */
+	public $overridden_settings;
+
+	/**
 	 * Last Error.
 	 *
 	 * @var [type]
@@ -45,6 +52,7 @@ class Postmark_Mail {
 		add_filter( 'init', array( $this, 'init' ) );
 
 		$this->settings = $this->load_settings();
+		$this->overridden_settings = include POSTMARK_DIR . '/postmark-settings.php';
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,9 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 1. Postmark WP Plugin Settings screen.
 
 == Changelog ==
+= v1.14.0 =
+* Adds ability to override settings for environment specific Postmark plugin settings.
+
 = v1.13.7 =
 * Fix limit of 500 sending logs deleted per day.
 

--- a/readme.txt
+++ b/readme.txt
@@ -59,10 +59,21 @@ Because we've been in this business for many years. We’ve been running an emai
 
 Most importantly, a great product requires great support and even better education. Our team is spread out across six time zones to offer fast support on everything from using Postmark to best practices on content and user engagement. A solid infrastructure only goes so far, that’s why improving our customer’s sending practices helps achieve incredible results
 
-
 = Why aren't my HTML emails being sent? =
 
 This plugin detects HTML by checking the headers sent by other WordPress plugins. If a "text/html" content type isn't set then this plugin won't send the HTML to Postmark to be sent out only the plain text version of the email.
+
+= How do I set environment specific Postmark plugin settings?
+
+You can optionally set the Postmark API Token, message stream, and default sending address by adding the following to your `wp-config.php` file:
+
+```
+define( 'POSTMARK_API_KEY', '<api token>' );
+define( 'POSTMARK_STREAM_NAME', 'stream-name' );
+define( 'POSTMARK_SENDER_ADDRESS', 'from@example.com' );
+```
+
+Setting any of these here will override what is set via the plugin's UI.
 
 = Why are password reset links not showing in emails sent with this plugin? =
 

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -52,7 +52,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	// Compact the input, apply the filters, and extract them back out.
 	extract( apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) ) );
 
-	$settings = json_decode( get_option( 'postmark_settings' ), true );
+	$settings = include POSTMARK_DIR . '/postmark-settings.php';
 
 	if ( ! is_array( $attachments ) ) {
 		$attachments = explode( "\n", str_replace( "\r\n", "\n", $attachments ) );

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -53,6 +53,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	extract( apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) ) );
 
 	$settings = include POSTMARK_DIR . '/postmark-settings.php';
+	$settings = $settings['settings'];
 
 	if ( ! is_array( $attachments ) ) {
 		$attachments = explode( "\n", str_replace( "\r\n", "\n", $attachments ) );


### PR DESCRIPTION
_This needs review and documentation before merging._

This PR allows you to set constants in your `wp-config.php` file which will override, but not overwrite, any settings stored in the database (WP options). API Key, Stream Name/ID, and Sender Address are supported. Example config:

```php
// setup Postmark constants
define('POSTMARK_API_KEY', 'xyz-123-abc');
define('POSTMARK_STREAM_NAME', null);
define('POSTMARK_SENDER_ADDRESS', 'from-constans@example.com');
```

An example usage would be for a developer to use settings from a Postmark Sandbox stream in their development environment that would survive database merges. See #71. This also helps address #72.
