### PR TITLE
Add option to force the from email

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 [Can I use the Postmark for WordPress plugin with Divi contact forms?](https://postmarkapp.com/support/article/1128-can-i-use-the-postmark-for-wordpress-plugin-with-divi-contact-forms)
 
 ## Changelog
+### v1.15. 0
+* Adds new Force From setting to allow preventing override of From address using headers, if desired.
+
 ### v1.14.0
 * Adds ability to override settings for environment specific Postmark plugin settings.
 

--- a/page-settings.php
+++ b/page-settings.php
@@ -88,13 +88,13 @@ wp_nonce_field( 'postmark_nonce' );
 					<div class="footnote">This email must be a verified <a href="https://account.postmarkapp.com/signatures" target="_blank">Sender Signature</a>. It will appear as the "from" address on all outbound emails.</div>
 				</td>
 			</tr>
-            <tr>
-                <th><label>Force Sender Email</label></th>
-                <td>
-                    <input type="checkbox" class="pm-force-from" value="1" />
-                    <span class="footnote">Force emails to be sent from the Sender Email specified above. Disallows overriding using the <code>$headers</code> array.</span>
-                </td>
-            </tr>
+		        <tr>
+                                <th><label>Force Sender Email</label></th>
+			        <td>
+			    		<input type="checkbox" class="pm-force-from" value="1" />
+			    		<span class="footnote">Force emails to be sent from the Sender Email specified above. Disallows overriding using the <code>$headers</code> array.</span>
+                		</td>
+            		</tr>
 			<tr>
 				<th><label>Force HTML</label></th>
 				<td>

--- a/page-settings.php
+++ b/page-settings.php
@@ -53,6 +53,10 @@ wp_nonce_field( 'postmark_nonce' );
 	<?php if ( isset( $this->overridden_settings['sender_address'] ) ) : ?>
 		<div class="notice notice-info"><code>POSTMARK_SENDER_ADDRESS</code> is defined in your wp-config.php and overrides the <code>Sender Email</code> set here.</div>
 	<?php endif; ?>
+    
+    <?php if ( isset( $this->overridden_settings['sender_address'] ) ) : ?>
+        <div class="notice notice-info"><code>POSTMARK_FORCE_FROM</code> is defined in your wp-config.php and overrides the <code>Force From</code> set here.</div>
+    <?php endif; ?>
 
 	<div class="tab-content tab-general">
 		<table class="form-table">
@@ -84,6 +88,13 @@ wp_nonce_field( 'postmark_nonce' );
 					<div class="footnote">This email must be a verified <a href="https://account.postmarkapp.com/signatures" target="_blank">Sender Signature</a>. It will appear as the "from" address on all outbound emails.</div>
 				</td>
 			</tr>
+            <tr>
+                <th><label>Force Sender Email</label></th>
+                <td>
+                    <input type="checkbox" class="pm-force-from" value="1" />
+                    <span class="footnote">Force emails to be sent from the Sender Email specified above. Disallows overriding using the <code>$headers</code> array.</span>
+                </td>
+            </tr>
 			<tr>
 				<th><label>Force HTML</label></th>
 				<td>
@@ -145,7 +156,7 @@ wp_nonce_field( 'postmark_nonce' );
 		<pre>
 		$headers = array();
 
-		// Override the default 'From' address
+		// Override the default 'From' address if 'Force Sender Email' is not enabled
 		$headers['From'] = 'john.smith@example.com';
 
 		// Send the message as HTML

--- a/postmark-settings.php
+++ b/postmark-settings.php
@@ -10,6 +10,7 @@ $settings_from_constants = array(
     'api_key'        => defined( 'POSTMARK_API_KEY' ) ? POSTMARK_API_KEY : null,
     'stream_name'    => defined( 'POSTMARK_STREAM_NAME' ) ? POSTMARK_STREAM_NAME : null,
     'sender_address' => defined( 'POSTMARK_SENDER_ADDRESS' ) ? POSTMARK_SENDER_ADDRESS : null,
+    'force_from'     => defined( 'POSTMARK_FORCE_FROM' ) ? POSTMARK_FORCE_FROM : null,
 );
 $settings_from_constants = array_filter( $settings_from_constants );
 $settings = array_merge( $settings, $settings_from_constants );

--- a/postmark.php
+++ b/postmark.php
@@ -81,7 +81,7 @@ class Postmark_Mail {
 				'api_key'        => get_option( 'postmark_api_key', '' ),
 				'stream_name'    => get_option( 'postmark_stream_name', 'outbound'),
 				'sender_address' => get_option( 'postmark_sender_address', '' ),
-                'force_from'     => get_option( 'postmark_force_from', 0 ),
+                		'force_from'     => get_option( 'postmark_force_from', 0 ),
 				'force_html'     => get_option( 'postmark_force_html', 0 ),
 				'track_opens'    => get_option( 'postmark_trackopens', 0 ),
 				'track_links'    => get_option( 'postmark_tracklinks', 0 ),
@@ -105,11 +105,11 @@ class Postmark_Mail {
 			return $settings;
 		}
         
-        if ( is_array( $settings ) && ! isset( $settings['force_from'] ) ) {
-            $settings['force_from'] = 0;
-            update_option( 'postmark_settings', wp_json_encode( $settings ) );
-            return $settings;
-        }
+		if ( is_array( $settings ) && ! isset( $settings['force_from'] ) ) {
+		        $settings['force_from'] = 0;
+		        update_option( 'postmark_settings', wp_json_encode( $settings ) );
+		        return $settings;
+		}
 
 		return json_decode( $settings, true );
 	}

--- a/postmark.php
+++ b/postmark.php
@@ -81,6 +81,7 @@ class Postmark_Mail {
 				'api_key'        => get_option( 'postmark_api_key', '' ),
 				'stream_name'    => get_option( 'postmark_stream_name', 'outbound'),
 				'sender_address' => get_option( 'postmark_sender_address', '' ),
+                'force_from'     => get_option( 'postmark_force_from', 0 ),
 				'force_html'     => get_option( 'postmark_force_html', 0 ),
 				'track_opens'    => get_option( 'postmark_trackopens', 0 ),
 				'track_links'    => get_option( 'postmark_tracklinks', 0 ),
@@ -103,6 +104,12 @@ class Postmark_Mail {
 			update_option( 'postmark_settings', wp_json_encode( $settings ) );
 			return $settings;
 		}
+        
+        if ( is_array( $settings ) && ! isset( $settings['force_from'] ) ) {
+            $settings['force_from'] = 0;
+            update_option( 'postmark_settings', wp_json_encode( $settings ) );
+            return $settings;
+        }
 
 		return json_decode( $settings, true );
 	}
@@ -275,6 +282,13 @@ class Postmark_Mail {
 		} else {
 			$settings['sender_address'] = '';
 		}
+        
+        // We validate that 'force_from' is a numeric boolean.
+        if ( isset( $data['force_from'] ) && 1 === $data['force_from'] ) {
+            $settings['force_from'] = 1;
+        } else {
+            $settings['force_from'] = 0;
+        }
 
 		// We validate that 'force_html' is a numeric boolean.
 		if ( isset( $data['force_html'] ) && 1 === $data['force_html'] ) {

--- a/postmark.php
+++ b/postmark.php
@@ -3,7 +3,7 @@
  * Plugin Name: Postmark (Official)
  * Plugin URI: https://postmarkapp.com/
  * Description: Overrides wp_mail to send emails through Postmark
- * Version: 1.14.0
+ * Version: 1.15.0
  * Author: Andrew Yates & Matt Gibbs
  */
 
@@ -38,7 +38,7 @@ class Postmark_Mail {
 	 */
 	public function __construct() {
 		if ( ! defined( 'POSTMARK_VERSION' ) ) {
-			define( 'POSTMARK_VERSION', '1.14.0' );
+			define( 'POSTMARK_VERSION', '1.15.0 );
 		}
 
 		if ( ! defined( 'POSTMARK_DIR' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,9 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 1. Postmark WP Plugin Settings screen.
 
 == Changelog ==
+= v.1.15.0 =
+* Adds new Force From setting to allow preventing override of From address using headers, if desired.
+
 = v1.14.0 =
 * Adds ability to override settings for environment specific Postmark plugin settings.
 

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -153,7 +153,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	// Allow overriding the From address when specified in the headers.
 	$from = $settings['sender_address'];
 
-	if ( isset( $recognized_headers['From'] ) ) {
+	if ( false === $settings['force_from'] && isset( $recognized_headers['From'] ) ) {
 		$from = $recognized_headers['From'];
 	}
 


### PR DESCRIPTION
As an agency, we work with a multitude of form plugins, contact forms and site maintainers. We usually set up Postmark using this plugin, but site administrators can and do change emailadresses, and sometimes change the wrong email, breaking the DKIM validation and not sending all email following. I would like to be able to force the sender email, so people don't accidentally break all email by changing the admin email for example.

This PR adds a setting (default off) to force a from email, and if this is enabled, doesn't allow the `$headers['From']` to override the from email.