### PR TITLE
Updated version of force sender email

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 [Can I use the Postmark for WordPress plugin with Divi contact forms?](https://postmarkapp.com/support/article/1128-can-i-use-the-postmark-for-wordpress-plugin-with-divi-contact-forms)
 
 ## Changelog
+### v1.15.1
+* Bugfix for using Force From setting.
+
 ### v1.15. 0
 * Adds new Force From setting to allow preventing override of From address using headers, if desired.
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -6,6 +6,7 @@
         $('.pm-api-key').val(settings.api_key);
         $('.pm-stream-name').val(settings.stream_name);
         $('.pm-sender-address').val(settings.sender_address);
+        $('.pm-force-from').prop('checked', settings.force_from);
         $('.pm-force-html').prop('checked', settings.force_html);
         $('.pm-track-opens').prop('checked', settings.track_opens);
         $('.pm-track-links').prop('checked', settings.track_links);
@@ -18,6 +19,7 @@
                 'api_key': $('.pm-api-key').val(),
                 'stream_name': $('.pm-stream-name').val() ? $('.pm-stream-name').val() : 'outbound',
                 'sender_address': $('.pm-sender-address').val(),
+                'force_from': $('.pm-force-from').is(':checked') ? 1 : 0,
                 'force_html': $('.pm-force-html').is(':checked') ? 1 : 0,
                 'track_opens': $('.pm-track-opens').is(':checked') ? 1 : 0,
                 'track_links': $('.pm-track-links').is(':checked') ? 1 : 0,

--- a/postmark.php
+++ b/postmark.php
@@ -3,7 +3,7 @@
  * Plugin Name: Postmark (Official)
  * Plugin URI: https://postmarkapp.com/
  * Description: Overrides wp_mail to send emails through Postmark
- * Version: 1.15.0
+ * Version: 1.15.1
  * Author: Andrew Yates & Matt Gibbs
  */
 
@@ -38,7 +38,7 @@ class Postmark_Mail {
 	 */
 	public function __construct() {
 		if ( ! defined( 'POSTMARK_VERSION' ) ) {
-			define( 'POSTMARK_VERSION', '1.15.0' );
+			define( 'POSTMARK_VERSION', '1.15.1' );
 		}
 
 		if ( ! defined( 'POSTMARK_DIR' ) ) {
@@ -104,7 +104,7 @@ class Postmark_Mail {
 			update_option( 'postmark_settings', wp_json_encode( $settings ) );
 			return $settings;
 		}
-        
+
 		if ( is_array( $settings ) && ! isset( $settings['force_from'] ) ) {
 		        $settings['force_from'] = 0;
 		        update_option( 'postmark_settings', wp_json_encode( $settings ) );
@@ -282,7 +282,7 @@ class Postmark_Mail {
 		} else {
 			$settings['sender_address'] = '';
 		}
-        
+
         // We validate that 'force_from' is a numeric boolean.
         if ( isset( $data['force_from'] ) && 1 === $data['force_from'] ) {
             $settings['force_from'] = 1;

--- a/postmark.php
+++ b/postmark.php
@@ -38,7 +38,7 @@ class Postmark_Mail {
 	 */
 	public function __construct() {
 		if ( ! defined( 'POSTMARK_VERSION' ) ) {
-			define( 'POSTMARK_VERSION', '1.15.0 );
+			define( 'POSTMARK_VERSION', '1.15.0' );
 		}
 
 		if ( ! defined( 'POSTMARK_DIR' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -114,7 +114,10 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 1. Postmark WP Plugin Settings screen.
 
 == Changelog ==
-= v.1.15.0 =
+= v1.15.1 =
+* Bugfix for using Force From setting.
+
+= v1.15.0 =
 * Adds new Force From setting to allow preventing override of From address using headers, if desired.
 
 = v1.14.0 =

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -153,7 +153,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	// Allow overriding the From address when specified in the headers.
 	$from = $settings['sender_address'];
 
-    $force_from = isset($settings['force_from']) && $settings['force_from'];
+    $force_from = isset( $settings['force_from'] ) && $settings['force_from'];
 	if ( false === $force_from && isset( $recognized_headers['From'] ) ) {
 		$from = $recognized_headers['From'];
 	}

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -153,7 +153,8 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	// Allow overriding the From address when specified in the headers.
 	$from = $settings['sender_address'];
 
-	if ( false === $settings['force_from'] && isset( $recognized_headers['From'] ) ) {
+    $force_from = isset($settings['force_from']) && $settings['force_from'];
+	if ( false === $force_from && isset( $recognized_headers['From'] ) ) {
 		$from = $recognized_headers['From'];
 	}
 


### PR DESCRIPTION
Added handling for non-existing settings so they will not get forced. Added JS to update settings. Tested sending with no 'force_from' setting present, and with the setting explicitly enabled and disabled.

This includes @pgraham3 commits with the version bump and formatting. 