### PR TITLE
Implement wp_mail_succeeded hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 [Can I use the Postmark for WordPress plugin with Divi contact forms?](https://postmarkapp.com/support/article/1128-can-i-use-the-postmark-for-wordpress-plugin-with-divi-contact-forms)
 
 ## Changelog
+### v1.15.6
+* Do wp_mail_succeeded action after successful sends (introduced in WordPress v5.9).
 ### v1.15.5
 * Honour pre_wp_mail filters.
 ### v1.15.4

--- a/postmark.php
+++ b/postmark.php
@@ -3,7 +3,7 @@
  * Plugin Name: Postmark (Official)
  * Plugin URI: https://postmarkapp.com/
  * Description: Overrides wp_mail to send emails through Postmark
- * Version: 1.15.5
+ * Version: 1.15.6
  * Author: Andrew Yates & Matt Gibbs
  */
 
@@ -38,7 +38,7 @@ class Postmark_Mail {
 	 */
 	public function __construct() {
 		if ( ! defined( 'POSTMARK_VERSION' ) ) {
-			define( 'POSTMARK_VERSION', '1.15.5' );
+			define( 'POSTMARK_VERSION', '1.15.6' );
 		}
 
 		if ( ! defined( 'POSTMARK_DIR' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,9 @@ The plugin supports using the `wp_mail_from_name` filter for manually setting a 
 1. Postmark WP Plugin Settings screen.
 
 == Changelog ==
+= v1.15.6 =
+* Do wp_mail_succeeded action after successful sends (introduced in WordPress v5.9).
+
 = v1.15.5 =
 * Honour pre_wp_mail filters.
 

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -314,5 +314,14 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 
 	do_action( 'postmark_response', $response, $headers );
 
+    // Support wp_mail_succeeded action
+    do_action('wp_mail_succeeded', array(
+        'to' => $body['From'],
+        'subject' => $body['Subject'],
+        'message' => $body['TextBody'] ?? $body['HtmlBody'],
+        'headers' => $recognized_headers,
+        'attachments' => $body['Attachments'] ?? null,
+    ));
+
 	return true;
 }

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -318,7 +318,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
     do_action('wp_mail_succeeded', array(
         'to' => $body['To'],
         'subject' => $body['Subject'],
-        'message' => $body['TextBody'] ?? $body['HtmlBody'],
+        'message' => $body['HtmlBody'] ?? $body['TextBody'],
         'headers' => $recognized_headers,
         'attachments' => $body['Attachments'] ?? null,
     ));

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -316,7 +316,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 
     // Support wp_mail_succeeded action
     do_action('wp_mail_succeeded', array(
-        'to' => $body['From'],
+        'to' => $body['To'],
         'subject' => $body['Subject'],
         'message' => $body['TextBody'] ?? $body['HtmlBody'],
         'headers' => $recognized_headers,


### PR DESCRIPTION
Hello,

I've added the [wp_mail_succeeded](https://developer.wordpress.org/reference/hooks/wp_mail_succeeded/) hook (recently added in WP 5.9) to the plugin's `wp_mail` method.  Pretty simple change, though I'm curious on opinions for what values should be passed to the hook, currently I've opted to pass the values that were actually sent to the Postmark API instead of the initially passed values to the `wp_mail` call.