### PR TITLE
Tested against WP version 6.7

### DIFF
--- a/postmark.php
+++ b/postmark.php
@@ -6,7 +6,7 @@
  * Version: 1.19.1
  * Requires PHP: 7.0
  * Requires at least: 5.3
- * Tested up to: 6.6
+ * Tested up to: 6.7
  * Author: Andrew Yates & Matt Gibbs
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: andy7629, alexknowshtml, mgibbs189, jptoto, atheken, prileygraham,
 Tags: postmark, email, smtp, notifications, wp_mail, wildbit
 Requires PHP: 7.0
 Requires at least: 5.3
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag: 1.19.1
 
 The *officially-supported* ActiveCampaign Postmark plugin for Wordpress.


### PR DESCRIPTION
Updates _tested up to_ version after manually testing plugin against latest WP version (`6.7`).