### PR TITLE
Allow sending custom headers

### DIFF
--- a/wp-mail.php
+++ b/wp-mail.php
@@ -357,7 +357,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
         'to' => $body['To'],
         'subject' => $body['Subject'],
         'message' => $body['HtmlBody'] ?? $body['TextBody'],
-        'headers' => $recognized_headers,
+        'headers' => array_merge( $custom_headers, $recognized_headers ),
         'attachments' => $body['Attachments'] ?? null,
     ));
 


### PR DESCRIPTION
When adding headers to the `$headers` array in the `wp_mail` filter, only a few recognized headers (`'Content-Type', 'Cc', 'Bcc', 'Reply-To', 'From', 'X-PM-Track-Opens', 'X-PM-TrackLinks', 'X-PM-Tag'`) are picked up by the plugin, and the rest is just silently dropped. This PR adds headers that are not recognised now (and used by the plugin internally) to a custom headers array that is sent to the Postmark API, and thus end up in the message sent by Postmark.